### PR TITLE
Fix telegram bot v.13

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -6,7 +6,7 @@ jobs:
   build:    
     runs-on: ubuntu-latest    
     steps:        
-    - uses: avkviring/telegram-github-action@v0.0.8
+    - uses: avkviring/telegram-github-action@v0.0.13
       env:
         telegram_to: ${{ secrets.TELEGRAM_TO }}  
         telegram_token: ${{ secrets.TELEGRAM_TOKEN }}


### PR DESCRIPTION
Updated version of the bot notifying that there was a push to the developer.
The group chat will receive a message when the "develop" branch is updated.
![tg_bot](https://user-images.githubusercontent.com/47379684/111812894-21399700-890b-11eb-8ba9-8c29d557699c.JPG)


Example:
==========================
Antz0x0z push to usetech-llc/nft_private
➞ Update notify.yml
==========================
