### PR TITLE
Fix missing await in test

### DIFF
--- a/tests/src/transfer.test.ts
+++ b/tests/src/transfer.test.ts
@@ -60,7 +60,7 @@ describe('Integration Test Transfer(recipient, collection_id, item_id, value)', 
         // tslint:disable-next-line:no-unused-expression
         expect(result.success).to.be.false;
       };
-      expect(badTransaction()).to.be.rejectedWith('Inability to pay some fees , e.g. account balance too low');
+      await expect(badTransaction()).to.be.rejectedWith('Inability to pay some fees , e.g. account balance too low');
     });
   });
 


### PR DESCRIPTION
```
21) Integration Test Transfer(recipient, collection_id, item_id, value)
       Inability to pay fees error message is correct:
     Uncaught RuntimeError: abort(AssertionError: expected promise to be rejected with an error including 'Inability to pay some fees , e.g. account balance too low' but got 'disconnected from ws://127.0.0.1:9944: 1000:: Normal connection closure'). Build with -s ASSERTIONS=1 for more info.
```