### PR TITLE
test: use rpc-port provided by polkadot-launch

### DIFF
--- a/launch-config.json
+++ b/launch-config.json
@@ -9,7 +9,6 @@
                 "rpcPort": 9843,
                 "port": 30444,
                 "flags": [
-                    "--rpc-port=9843",
                     "-lparachain::candidate_validation=debug"
                 ]
             },
@@ -19,7 +18,6 @@
                 "rpcPort": 9854,
                 "port": 30555,
                 "flags": [
-                    "--rpc-port=9854",
                     "-lparachain::candidate_validation=debug"
                 ]
             },
@@ -29,7 +27,6 @@
                 "rpcPort": 9865,
                 "port": 30666,
                 "flags": [
-                    "--rpc-port=9865",
                     "-lparachain::candidate_validation=debug"
                 ]
             },
@@ -39,7 +36,6 @@
                 "rpcPort": 9876,
                 "port": 30777,
                 "flags": [
-                    "--rpc-port=9876",
                     "-lparachain::candidate_validation=debug"
                 ]
             }
@@ -70,7 +66,6 @@
                     "name": "alice",
                     "flags": [
                         "--rpc-cors=all",
-                        "--rpc-port=9933",
                         "--unsafe-rpc-external",
                         "--unsafe-ws-external"
                     ]
@@ -82,7 +77,6 @@
                     "name": "bob",
                     "flags": [
                         "--rpc-cors=all",
-                        "--rpc-port=9934",
                         "--unsafe-rpc-external",
                         "--unsafe-ws-external"
                     ]


### PR DESCRIPTION
polkadot-launch upgrade is required