### PR TITLE
CORE-248: refactor contract-helpers

### DIFF
--- a/pallets/contract-helpers/src/lib.rs
+++ b/pallets/contract-helpers/src/lib.rs
@@ -160,7 +160,11 @@ pub mod pallet {
 				<Error<T>>::NoPermission
 			);
 
-			<SponsoringRateLimit<T>>::insert(contract, rate_limit);
+			if rate_limit != T::DefaultSponsoringRateLimit::get() {
+				<SponsoringRateLimit<T>>::insert(contract, rate_limit);
+			} else {
+				<SponsoringRateLimit<T>>::remove(contract);
+			}
 			Ok(())
 		}
 	}


### PR DESCRIPTION
inserting default values into SponsoringRateLimit now removes the entry, forcing to use the default value