### PR TITLE
Use default runtime in the local testnet

### DIFF
--- a/node/cli/src/chain_spec.rs
+++ b/node/cli/src/chain_spec.rs
@@ -171,7 +171,9 @@ macro_rules! testnet_genesis {
 				key: Some($root_key),
 			},
 			vesting: VestingConfig { vesting: vec![] },
-			parachain_info: ParachainInfoConfig { parachain_id: $id.into() },
+			parachain_info: ParachainInfoConfig {
+				parachain_id: $id.into(),
+			},
 			parachain_system: Default::default(),
 			aura: AuraConfig {
 				authorities: $initial_authorities,
@@ -200,7 +202,6 @@ pub fn development_config() -> OpalChainSpec {
 		move || {
 			testnet_genesis!(
 				opal_runtime,
-
 				// Sudo account
 				get_account_id_from_seed::<sr25519::Public>("Alice"),
 				vec![
@@ -236,22 +237,29 @@ pub fn local_testnet_rococo_config() -> DefaultChainSpec {
 	let mut properties = Map::new();
 	properties.insert("tokenSymbol".into(), default_runtime::TOKEN_SYMBOL.into());
 	properties.insert("tokenDecimals".into(), 18.into());
-	properties.insert("ss58Format".into(), default_runtime::SS58Prefix::get().into());
+	properties.insert(
+		"ss58Format".into(),
+		default_runtime::SS58Prefix::get().into(),
+	);
 
 	DefaultChainSpec::from_genesis(
 		// Name
 		format!(
 			"{}{}",
 			default_runtime::RUNTIME_NAME.to_uppercase(),
-			if cfg!(feature = "unique-runtime") { "" } else { " by UNIQUE" }
-		).as_str(),
+			if cfg!(feature = "unique-runtime") {
+				""
+			} else {
+				" by UNIQUE"
+			}
+		)
+		.as_str(),
 		// ID
 		format!("{}_local", default_runtime::RUNTIME_NAME).as_str(),
 		ChainType::Local,
 		move || {
 			testnet_genesis!(
 				default_runtime,
-
 				// Sudo account
 				get_account_id_from_seed::<sr25519::Public>("Alice"),
 				vec![

--- a/runtime/opal/src/lib.rs
+++ b/runtime/opal/src/lib.rs
@@ -115,6 +115,7 @@ use sp_runtime::traits::CheckedConversion;
 use unique_runtime_common::{impl_common_runtime_apis, types::*, constants::*};
 
 pub const RUNTIME_NAME: &str = "opal";
+pub const TOKEN_SYMBOL: &str = "OPL";
 
 type CrossAccountId = pallet_common::account::BasicCrossAccountId<Runtime>;
 

--- a/runtime/quartz/src/lib.rs
+++ b/runtime/quartz/src/lib.rs
@@ -115,6 +115,7 @@ use sp_runtime::traits::CheckedConversion;
 use unique_runtime_common::{impl_common_runtime_apis, types::*, constants::*};
 
 pub const RUNTIME_NAME: &str = "quartz";
+pub const TOKEN_SYMBOL: &str = "QTZ";
 
 type CrossAccountId = pallet_common::account::BasicCrossAccountId<Runtime>;
 

--- a/runtime/unique/src/lib.rs
+++ b/runtime/unique/src/lib.rs
@@ -114,6 +114,7 @@ use sp_runtime::traits::CheckedConversion;
 use unique_runtime_common::{impl_common_runtime_apis, types::*, constants::*};
 
 pub const RUNTIME_NAME: &str = "unique";
+pub const TOKEN_SYMBOL: &str = "UNQ";
 
 type CrossAccountId = pallet_common::account::BasicCrossAccountId<Runtime>;
 


### PR DESCRIPTION
If feature `unique-runtime` is enabled, then Unique Runtime will be used in the local testnet.
The same for the Quartz runtime.

If neither `unique-runtime` nor `quartz-runtime` is enabled, then Opal Runtime will be used