### PR TITLE
fix: serde rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12379,7 +12379,7 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "uc-rpc"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "jsonrpsee",

--- a/client/rpc/CHANGELOG.md
+++ b/client/rpc/CHANGELOG.md
@@ -2,10 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.2] - 2022-08-12
+
+### Fixed
+
+-   Method signature `total_pieces`. Before that the number of pieces greater than 2^53 -1 caused an error when calling this method.
+
 ## [0.1.1] - 2022-07-14
 
 ### Added
 
- - Implementation of RPC method `token_owners` returning 10 owners in no particular order.
-    This was an internal request to improve the web interface and support fractionalization event. 
- 
+-   Implementation of RPC method `token_owners` returning 10 owners in no particular order.
+    This was an internal request to improve the web interface and support fractionalization event.

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uc-rpc"
-version = "0.1.1"
+version = "0.1.2"
 license = "GPLv3"
 edition = "2021"
 

--- a/client/rpc/src/lib.rs
+++ b/client/rpc/src/lib.rs
@@ -242,7 +242,7 @@ pub trait UniqueApi<BlockHash, CrossAccountId, AccountId> {
 		collection_id: CollectionId,
 		token_id: TokenId,
 		at: Option<BlockHash>,
-	) -> Result<Option<u128>>;
+	) -> Result<Option<String>>;
 }
 
 mod rmrk_unique_rpc {
@@ -518,7 +518,7 @@ where
 	pass_method!(collection_stats() -> CollectionStats, unique_api);
 	pass_method!(next_sponsored(collection: CollectionId, account: CrossAccountId, token: TokenId) -> Option<u64>, unique_api);
 	pass_method!(effective_collection_limits(collection_id: CollectionId) -> Option<CollectionLimits>, unique_api);
-	pass_method!(total_pieces(collection_id: CollectionId, token_id: TokenId) -> Option<u128>, unique_api);
+	pass_method!(total_pieces(collection_id: CollectionId, token_id: TokenId) -> Option<String> => |o| o.map(|number| number.to_string()) , unique_api);
 	pass_method!(token_owners(collection: CollectionId, token: TokenId) -> Vec<CrossAccountId>, unique_api);
 }
 

--- a/pallets/common/src/lib.rs
+++ b/pallets/common/src/lib.rs
@@ -536,7 +536,7 @@ pub mod pallet {
 		/// Can't transfer tokens to ethereum zero address
 		AddressIsZero,
 
-		/// The oprtation is not supported
+		/// The operation is not supported
 		UnsupportedOperation,
 
 		/// Insufficient funds to perform an action

--- a/tests/CHANGELOG.md
+++ b/tests/CHANGELOG.md
@@ -2,10 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2022-08-12
+
+### Added
+
+-   In integration tests for `RFT` added check of work with the maximum allowable number of pieces (MAX_REFUNGIBLE_PIECES).
+
 ## 2022-07-14
 
 ### Added
- - Integrintegration tests of RPC method `token_owners`.
- - Integrintegration tests of Fungible Pallet.
-  
- 
+
+-   Integrintegration tests of RPC method `token_owners`.
+-   Integrintegration tests of Fungible Pallet.


### PR DESCRIPTION
Fixed method signature `total_pieces`. Before that the number of pieces greater than 2^53 -1 caused an error when calling this method.