### PR TITLE
evm-coder: conditional interface inheritance

### DIFF
--- a/crates/evm-coder/procedural/src/solidity_interface.rs
+++ b/crates/evm-coder/procedural/src/solidity_interface.rs
@@ -158,7 +158,7 @@ impl Parse for IsList {
 				parenthesized!(contents in input);
 				let input = contents;
 
-				loop {
+				while !input.is_empty() {
 					let lookahead = input.lookahead1();
 					if lookahead.peek(Token![if]) {
 						input.parse::<Token![if]>()?;
@@ -181,16 +181,10 @@ impl Parse for IsList {
 						if via.replace((ty, method)).is_some() {
 							return Err(syn::Error::new(input.span(), "via is already set"));
 						}
-					} else if input.is_empty() {
-						break;
-					} else {
-						return Err(lookahead.error());
-					}
-
-					if input.peek(Token![,]) {
+					} else if input.peek(Token![,]) {
 						input.parse::<Token![,]>()?;
 					} else {
-						break;
+						return Err(lookahead.error());
 					}
 				}
 			} else if lookahead.peek(Token![,]) || input.is_empty() {

--- a/crates/evm-coder/procedural/src/solidity_interface.rs
+++ b/crates/evm-coder/procedural/src/solidity_interface.rs
@@ -187,6 +187,8 @@ impl Parse for IsList {
 
 					if input.peek(Token![,]) {
 						input.parse::<Token![,]>()?;
+					} else if !input.is_empty() {
+						return Err(syn::Error::new(input.span(), "expected end"));
 					}
 				}
 			} else if lookahead.peek(Token![,]) || input.is_empty() {

--- a/crates/evm-coder/procedural/src/solidity_interface.rs
+++ b/crates/evm-coder/procedural/src/solidity_interface.rs
@@ -175,7 +175,7 @@ impl Parse for IsList {
 						parenthesized!(contents in input);
 
 						let method = contents.parse::<Ident>()?;
-						contents.parse::<Token![,]>()?;
+						contents.parse::<kw::returns>()?;
 						let ty = contents.parse::<Type>()?;
 
 						if via.replace((ty, method)).is_some() {
@@ -536,6 +536,7 @@ mod kw {
 	syn::custom_keyword!(weight);
 
 	syn::custom_keyword!(via);
+	syn::custom_keyword!(returns);
 	syn::custom_keyword!(name);
 	syn::custom_keyword!(is);
 	syn::custom_keyword!(inline_is);

--- a/crates/evm-coder/procedural/src/solidity_interface.rs
+++ b/crates/evm-coder/procedural/src/solidity_interface.rs
@@ -181,10 +181,12 @@ impl Parse for IsList {
 						if via.replace((ty, method)).is_some() {
 							return Err(syn::Error::new(input.span(), "via is already set"));
 						}
-					} else if input.peek(Token![,]) {
-						input.parse::<Token![,]>()?;
 					} else {
 						return Err(lookahead.error());
+					}
+
+					if input.peek(Token![,]) {
+						input.parse::<Token![,]>()?;
 					}
 				}
 			} else if lookahead.peek(Token![,]) || input.is_empty() {

--- a/crates/evm-coder/src/abi.rs
+++ b/crates/evm-coder/src/abi.rs
@@ -313,7 +313,7 @@ impl AbiWriter {
 	/// Finish writer, concatenating all internal buffers
 	pub fn finish(mut self) -> Vec<u8> {
 		for (static_offset, part) in self.dynamic_part {
-			let part_offset = self.static_part.len() - self.had_call.then(|| 4).unwrap_or(0);
+			let part_offset = self.static_part.len() - if self.had_call { 4 } else { 0 };
 
 			let encoded_dynamic_offset = usize::to_be_bytes(part_offset);
 			self.static_part[static_offset + ABI_ALIGNMENT - encoded_dynamic_offset.len()

--- a/crates/evm-coder/src/lib.rs
+++ b/crates/evm-coder/src/lib.rs
@@ -74,10 +74,10 @@ pub mod execution;
 /// #[solidity_interface(name = MyContract, is(SuperContract), inline_is(InlineContract))]
 /// impl Contract {
 ///     /// Multiply two numbers
-/// 	/// @param a First number
-/// 	/// @param b Second number
-/// 	/// @return uint32 Product of two passed numbers
-/// 	/// @dev This function returns error in case of overflow
+///     /// @param a First number
+///     /// @param b Second number
+///     /// @return uint32 Product of two passed numbers
+///     /// @dev This function returns error in case of overflow
 ///     #[weight(200 + a + b)]
 ///     #[solidity_interface(rename_selector = "mul")]
 ///     fn mul(&mut self, a: uint32, b: uint32) -> Result<uint32> {

--- a/crates/evm-coder/tests/conditional_is.rs
+++ b/crates/evm-coder/tests/conditional_is.rs
@@ -1,0 +1,44 @@
+use evm_coder::{types::*, solidity_interface, execution::Result, Call};
+
+pub struct Contract(bool);
+
+#[solidity_interface(name = A)]
+impl Contract {
+	fn method_a() -> Result<void> {
+		Ok(())
+	}
+}
+
+#[solidity_interface(name = B)]
+impl Contract {
+	fn method_b() -> Result<void> {
+		Ok(())
+	}
+}
+
+#[solidity_interface(name = Contract, is(
+	A(if(this.0)),
+	B(if(!this.0)),
+))]
+impl Contract {}
+
+#[test]
+fn conditional_erc165() {
+	assert!(ContractCall::supports_interface(
+		&Contract(true),
+		ACall::METHOD_A
+	));
+	assert!(!ContractCall::supports_interface(
+		&Contract(false),
+		ACall::METHOD_A
+	));
+
+	assert!(ContractCall::supports_interface(
+		&Contract(false),
+		BCall::METHOD_B
+	));
+	assert!(!ContractCall::supports_interface(
+		&Contract(true),
+		BCall::METHOD_B
+	));
+}

--- a/crates/evm-coder/tests/generics.rs
+++ b/crates/evm-coder/tests/generics.rs
@@ -17,7 +17,7 @@
 use std::marker::PhantomData;
 use evm_coder::{execution::Result, generate_stubgen, solidity_interface, types::*};
 
-struct Generic<T>(PhantomData<T>);
+pub struct Generic<T>(PhantomData<T>);
 
 #[solidity_interface(name = GenericIs)]
 impl<T> Generic<T> {

--- a/crates/evm-coder/tests/random.rs
+++ b/crates/evm-coder/tests/random.rs
@@ -18,7 +18,7 @@
 
 use evm_coder::{ToLog, execution::Result, solidity_interface, types::*, solidity, weight};
 
-struct Impls;
+pub struct Impls;
 
 #[solidity_interface(name = OurInterface)]
 impl Impls {

--- a/crates/evm-coder/tests/solidity_generation.rs
+++ b/crates/evm-coder/tests/solidity_generation.rs
@@ -16,7 +16,7 @@
 
 use evm_coder::{execution::Result, generate_stubgen, solidity_interface, types::*};
 
-struct ERC20;
+pub struct ERC20;
 
 #[solidity_interface(name = ERC20)]
 impl ERC20 {

--- a/pallets/common/src/erc.rs
+++ b/pallets/common/src/erc.rs
@@ -374,9 +374,9 @@ where
 			true => {
 				let mut bv = OwnerRestrictedSet::new();
 				for i in collections {
-					bv.try_insert(crate::eth::map_eth_to_id(&i).ok_or(Error::Revert(
-						"Can't convert address into collection id".into(),
-					))?)
+					bv.try_insert(crate::eth::map_eth_to_id(&i).ok_or_else(|| {
+						Error::Revert("Can't convert address into collection id".into())
+					})?)
 					.map_err(|_| "too many collections")?;
 				}
 				let mut nesting = permissions.nesting().clone();

--- a/pallets/fungible/src/erc.rs
+++ b/pallets/fungible/src/erc.rs
@@ -199,7 +199,7 @@ impl<T: Config> FungibleHandle<T> {
 		ERC20,
 		ERC20Mintable,
 		ERC20UniqueExtensions,
-		Collection(common_mut, CollectionHandle<T>),
+		Collection(via(common_mut, CollectionHandle<T>)),
 	)
 )]
 impl<T: Config> FungibleHandle<T> where T::AccountId: From<[u8; 32]> + AsRef<[u8; 32]> {}

--- a/pallets/fungible/src/erc.rs
+++ b/pallets/fungible/src/erc.rs
@@ -199,7 +199,7 @@ impl<T: Config> FungibleHandle<T> {
 		ERC20,
 		ERC20Mintable,
 		ERC20UniqueExtensions,
-		Collection(via(common_mut, CollectionHandle<T>)),
+		Collection(via(common_mut returns CollectionHandle<T>)),
 	)
 )]
 impl<T: Config> FungibleHandle<T> where T::AccountId: From<[u8; 32]> + AsRef<[u8; 32]> {}

--- a/pallets/nonfungible/src/erc.rs
+++ b/pallets/nonfungible/src/erc.rs
@@ -736,7 +736,7 @@ impl<T: Config> NonfungibleHandle<T> {
 		ERC721UniqueExtensions,
 		ERC721Mintable,
 		ERC721Burnable,
-		Collection(via(common_mut, CollectionHandle<T>)),
+		Collection(via(common_mut returns CollectionHandle<T>)),
 		TokenProperties,
 	)
 )]

--- a/pallets/nonfungible/src/erc.rs
+++ b/pallets/nonfungible/src/erc.rs
@@ -736,7 +736,7 @@ impl<T: Config> NonfungibleHandle<T> {
 		ERC721UniqueExtensions,
 		ERC721Mintable,
 		ERC721Burnable,
-		Collection(common_mut, CollectionHandle<T>),
+		Collection(via(common_mut, CollectionHandle<T>)),
 		TokenProperties,
 	)
 )]

--- a/pallets/refungible/src/erc.rs
+++ b/pallets/refungible/src/erc.rs
@@ -785,7 +785,7 @@ impl<T: Config> RefungibleHandle<T> {
 		ERC721UniqueExtensions,
 		ERC721Mintable,
 		ERC721Burnable,
-		Collection(common_mut, CollectionHandle<T>),
+		Collection(via(common_mut, CollectionHandle<T>)),
 		TokenProperties,
 	)
 )]

--- a/pallets/refungible/src/erc.rs
+++ b/pallets/refungible/src/erc.rs
@@ -785,7 +785,7 @@ impl<T: Config> RefungibleHandle<T> {
 		ERC721UniqueExtensions,
 		ERC721Mintable,
 		ERC721Burnable,
-		Collection(via(common_mut, CollectionHandle<T>)),
+		Collection(via(common_mut returns CollectionHandle<T>)),
 		TokenProperties,
 	)
 )]


### PR DESCRIPTION
Add new configuration option for `#[solidity_interface]` `is` attribute: `if($expr)`

This expression will be executed during ERC165 `supports_interface` call, and during normal call execution (but not during parsing), allowing to conditionally disable some inherited interfaces based on contract data