### PR TITLE
add draft check for each re-usable workflow

### DIFF
--- a/.github/workflows/ci-develop.yml
+++ b/.github/workflows/ci-develop.yml
@@ -3,7 +3,7 @@ name: develop
 on:
   pull_request:
     branches: [ 'develop' ]
-    types: [ opened, reopened, synchronize, ready_for_review ]
+    types: [ opened, reopened, synchronize, ready_for_review, converted_to_draft ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
@@ -12,23 +12,28 @@ concurrency:
 jobs:
 
   yarn-test-dev:
+    if: github.event.pull_request.draft == false
     uses: ./.github/workflows/dev-build-tests_v2.yml
 
+
   unit-test:
+    if: github.event.pull_request.draft == false
     uses: ./.github/workflows/unit-test_v2.yml
 
   canary:
-    if: ${{ contains( github.event.pull_request.labels.*.name, 'canary') }}
+    if: ${{ (github.event.pull_request.draft == false && contains( github.event.pull_request.labels.*.name, 'canary')) }}
     uses: ./.github/workflows/canary.yml
     secrets: inherit # pass all secrets
 
   xcm:
-    if: ${{ contains( github.event.pull_request.labels.*.name, 'xcm') }}
+    if: ${{ (github.event.pull_request.draft == false && contains( github.event.pull_request.labels.*.name, 'xcm')) }}
     uses: ./.github/workflows/xcm.yml
     secrets: inherit # pass all secrets
 
   codestyle:
+    if: github.event.pull_request.draft == false
     uses: ./.github/workflows/codestyle_v2.yml
   
   yarn_eslint:
+    if: github.event.pull_request.draft == false
     uses: ./.github/workflows/test_codestyle_v2.yml


### PR DESCRIPTION
Добавляем:
- проверку PR На статус draft
- запуск workflow при событие converted_to_draft, это останавливает выполнение workflow и завершает все работающие actions, тем самым высвобождая github runners для других задач.