### PR TITLE
fix evm-stubs:

### DIFF
--- a/crates/evm-coder/CHANGELOG.md
+++ b/crates/evm-coder/CHANGELOG.md
@@ -3,25 +3,28 @@
 All notable changes to this project will be documented in this file.
 
 <!-- bureaucrate goes here -->
+
 ## [v0.1.4] - 2022-11-02
+
 ### Added
- - Named structures support.
+
+- Named structures support.
 
 ## [v0.1.3] - 2022-08-29
 
 ### Fixed
 
- - Parsing simple values.
+- Parsing simple values.
 
 ## [v0.1.2] 2022-08-19
 
 ### Added
 
- - Implementation `AbiWrite` for tuples.
+- Implementation `AbiWrite` for tuples.
 
- ### Fixes
+### Fixes
 
- - Tuple generation for solidity.
+- Tuple generation for solidity.
 
 ## [v0.1.1] 2022-08-16
 

--- a/crates/evm-coder/procedural/src/solidity_interface.rs
+++ b/crates/evm-coder/procedural/src/solidity_interface.rs
@@ -928,10 +928,13 @@ impl SolidityInterface {
 			.chain(self.info.inline_is.0.iter())
 			.map(|is| Is::expand_generator(is, &gen_ref));
 		let solidity_event_generators = self.info.events.0.iter().map(Is::expand_event_generator);
-
+		let solidity_events_idents = self.info.events.0.iter().map(|is| is.name.clone());
 		let docs = &self.docs;
 
 		quote! {
+			#(
+				const _: ::core::marker::PhantomData<#solidity_events_idents> = ::core::marker::PhantomData;
+			)*
 			#[derive(Debug)]
 			#(#[doc = #docs])*
 			pub enum #call_name #gen_ref {

--- a/pallets/unique/Cargo.toml
+++ b/pallets/unique/Cargo.toml
@@ -34,7 +34,7 @@ std = [
 ]
 try-runtime = ["frame-support/try-runtime"]
 limit-testing = ["up-data-structs/limit-testing"]
-
+stubgen = ["evm-coder/stubgen", "pallet-common/stubgen"]
 ################################################################################
 # Standart Dependencies
 

--- a/pallets/unique/src/eth/mod.rs
+++ b/pallets/unique/src/eth/mod.rs
@@ -23,7 +23,10 @@ use frame_support::traits::Get;
 use crate::Pallet;
 
 use pallet_common::{
-	CollectionById, dispatch::CollectionDispatch, erc::static_property::key, Pallet as PalletCommon,
+	CollectionById,
+	dispatch::CollectionDispatch,
+	erc::{static_property::key, CollectionHelpersEvents},
+	Pallet as PalletCommon,
 };
 use pallet_evm::{account::CrossAccountId, OnMethodCall, PrecompileHandle, PrecompileResult};
 use pallet_evm_coder_substrate::{dispatch_to_evm, SubstrateRecorder, WithRecorder};


### PR DESCRIPTION
Changed behavior for `solidity_interface` macro. Fixed use of enums events for features not related to stub generation.