### PR TITLE
feature: delete properties

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6376,7 +6376,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-nonfungible"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "ethereum",
  "evm-coder",
@@ -6498,7 +6498,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-refungible"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "derivative",
  "ethereum",

--- a/pallets/nonfungible/CHANGELOG.md
+++ b/pallets/nonfungible/CHANGELOG.md
@@ -3,9 +3,18 @@
 All notable changes to this project will be documented in this file.
 
 <!-- bureaucrate goes here -->
-## [v0.1.7] - 2022-11-02
+
+## [v0.1.8] - 2022-11-11
+
 ### Changed
- - Use named structure `EthCrossAccount` in eth functions.
+
+- Added `delete_properties` in eth functions. The `delete_property` function is now deprecated.
+
+## [v0.1.7] - 2022-11-02
+
+### Changed
+
+- Use named structure `EthCrossAccount` in eth functions.
 
 ## [v0.1.6] - 2022-20-10
 

--- a/pallets/nonfungible/Cargo.toml
+++ b/pallets/nonfungible/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-nonfungible"
-version = "0.1.7"
+version = "0.1.8"
 license = "GPLv3"
 edition = "2021"
 

--- a/pallets/nonfungible/src/erc.rs
+++ b/pallets/nonfungible/src/erc.rs
@@ -162,6 +162,7 @@ impl<T: Config> NonfungibleHandle<T> {
 	/// @dev Throws error if `msg.sender` has no permission to edit the property.
 	/// @param tokenId ID of the token.
 	/// @param key Property key.
+	#[solidity(hide)]
 	fn delete_property(&mut self, token_id: uint256, caller: caller, key: string) -> Result<()> {
 		let caller = T::CrossAccountId::from_eth(caller);
 		let token_id: u32 = token_id.try_into().map_err(|_| "token id overflow")?;
@@ -175,6 +176,37 @@ impl<T: Config> NonfungibleHandle<T> {
 
 		<Pallet<T>>::delete_token_property(self, &caller, TokenId(token_id), key, &nesting_budget)
 			.map_err(dispatch_to_evm::<T>)
+	}
+
+	/// @notice Delete token properties value.
+	/// @dev Throws error if `msg.sender` has no permission to edit the property.
+	/// @param tokenId ID of the token.
+	/// @param keys Properties key.
+	fn delete_properties(
+		&mut self,
+		token_id: uint256,
+		caller: caller,
+		keys: Vec<string>,
+	) -> Result<()> {
+		let caller = T::CrossAccountId::from_eth(caller);
+		let token_id: u32 = token_id.try_into().map_err(|_| "token id overflow")?;
+		let keys = keys
+			.into_iter()
+			.map(|k| Ok(<Vec<u8>>::from(k).try_into().map_err(|_| "key too long")?))
+			.collect::<Result<Vec<_>>>()?;
+
+		let nesting_budget = self
+			.recorder
+			.weight_calls_budget(<StructureWeight<T>>::find_parent());
+
+		<Pallet<T>>::delete_token_properties(
+			self,
+			&caller,
+			TokenId(token_id),
+			keys.into_iter(),
+			&nesting_budget,
+		)
+		.map_err(dispatch_to_evm::<T>)
 	}
 
 	/// @notice Get token property value.

--- a/pallets/nonfungible/src/stubs/UniqueNFT.sol
+++ b/pallets/nonfungible/src/stubs/UniqueNFT.sol
@@ -18,7 +18,7 @@ contract ERC165 is Dummy {
 }
 
 /// @title A contract that allows to set and delete token properties and change token property permissions.
-/// @dev the ERC-165 identifier for this interface is 0x55dba919
+/// @dev the ERC-165 identifier for this interface is 0x91a97a68
 contract TokenProperties is Dummy, ERC165 {
 	/// @notice Set permissions for token property.
 	/// @dev Throws error if `msg.sender` is not admin or owner of the collection.
@@ -74,16 +74,29 @@ contract TokenProperties is Dummy, ERC165 {
 		dummy = 0;
 	}
 
-	/// @notice Delete token property value.
+	// /// @notice Delete token property value.
+	// /// @dev Throws error if `msg.sender` has no permission to edit the property.
+	// /// @param tokenId ID of the token.
+	// /// @param key Property key.
+	// /// @dev EVM selector for this function is: 0x066111d1,
+	// ///  or in textual repr: deleteProperty(uint256,string)
+	// function deleteProperty(uint256 tokenId, string memory key) public {
+	// 	require(false, stub_error);
+	// 	tokenId;
+	// 	key;
+	// 	dummy = 0;
+	// }
+
+	/// @notice Delete token properties value.
 	/// @dev Throws error if `msg.sender` has no permission to edit the property.
 	/// @param tokenId ID of the token.
-	/// @param key Property key.
-	/// @dev EVM selector for this function is: 0x066111d1,
-	///  or in textual repr: deleteProperty(uint256,string)
-	function deleteProperty(uint256 tokenId, string memory key) public {
+	/// @param keys Properties key.
+	/// @dev EVM selector for this function is: 0xc472d371,
+	///  or in textual repr: deleteProperties(uint256,string[])
+	function deleteProperties(uint256 tokenId, string[] memory keys) public {
 		require(false, stub_error);
 		tokenId;
-		key;
+		keys;
 		dummy = 0;
 	}
 

--- a/pallets/refungible/CHANGELOG.md
+++ b/pallets/refungible/CHANGELOG.md
@@ -2,9 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
-## [v0.2.6] - 2022-11-02
+<!-- bureaucrate goes here -->
+
+## [v0.2.7] - 2022-11-11
+
 ### Changed
- - Use named structure `EthCrossAccount` in eth functions.
+
+- Added `delete_properties` in eth functions. The `delete_property` function is now deprecated.
+
+## [v0.2.6] - 2022-11-02
+
+### Changed
+
+- Use named structure `EthCrossAccount` in eth functions.
 
 ## [v0.2.5] - 2022-20-10
 
@@ -17,8 +27,6 @@ All notable changes to this project will be documented in this file.
 ### Change
 
 - Add bound `AsRef<[u8; 32]>` to `T::CrossAccountId`.
-
-<!-- bureaucrate goes here -->
 
 ## [v0.2.3] 2022-08-16
 

--- a/pallets/refungible/Cargo.toml
+++ b/pallets/refungible/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-refungible"
-version = "0.2.6"
+version = "0.2.7"
 license = "GPLv3"
 edition = "2021"
 

--- a/pallets/refungible/src/stubs/UniqueRefungible.sol
+++ b/pallets/refungible/src/stubs/UniqueRefungible.sol
@@ -18,7 +18,7 @@ contract ERC165 is Dummy {
 }
 
 /// @title A contract that allows to set and delete token properties and change token property permissions.
-/// @dev the ERC-165 identifier for this interface is 0x55dba919
+/// @dev the ERC-165 identifier for this interface is 0x91a97a68
 contract TokenProperties is Dummy, ERC165 {
 	/// @notice Set permissions for token property.
 	/// @dev Throws error if `msg.sender` is not admin or owner of the collection.
@@ -74,16 +74,29 @@ contract TokenProperties is Dummy, ERC165 {
 		dummy = 0;
 	}
 
-	/// @notice Delete token property value.
+	// /// @notice Delete token property value.
+	// /// @dev Throws error if `msg.sender` has no permission to edit the property.
+	// /// @param tokenId ID of the token.
+	// /// @param key Property key.
+	// /// @dev EVM selector for this function is: 0x066111d1,
+	// ///  or in textual repr: deleteProperty(uint256,string)
+	// function deleteProperty(uint256 tokenId, string memory key) public {
+	// 	require(false, stub_error);
+	// 	tokenId;
+	// 	key;
+	// 	dummy = 0;
+	// }
+
+	/// @notice Delete token properties value.
 	/// @dev Throws error if `msg.sender` has no permission to edit the property.
 	/// @param tokenId ID of the token.
-	/// @param key Property key.
-	/// @dev EVM selector for this function is: 0x066111d1,
-	///  or in textual repr: deleteProperty(uint256,string)
-	function deleteProperty(uint256 tokenId, string memory key) public {
+	/// @param keys Properties key.
+	/// @dev EVM selector for this function is: 0xc472d371,
+	///  or in textual repr: deleteProperties(uint256,string[])
+	function deleteProperties(uint256 tokenId, string[] memory keys) public {
 		require(false, stub_error);
 		tokenId;
-		key;
+		keys;
 		dummy = 0;
 	}
 

--- a/tests/src/eth/api/UniqueNFT.sol
+++ b/tests/src/eth/api/UniqueNFT.sol
@@ -13,7 +13,7 @@ interface ERC165 is Dummy {
 }
 
 /// @title A contract that allows to set and delete token properties and change token property permissions.
-/// @dev the ERC-165 identifier for this interface is 0x55dba919
+/// @dev the ERC-165 identifier for this interface is 0x91a97a68
 interface TokenProperties is Dummy, ERC165 {
 	/// @notice Set permissions for token property.
 	/// @dev Throws error if `msg.sender` is not admin or owner of the collection.
@@ -51,13 +51,21 @@ interface TokenProperties is Dummy, ERC165 {
 	///  or in textual repr: setProperties(uint256,(string,bytes)[])
 	function setProperties(uint256 tokenId, Tuple21[] memory properties) external;
 
-	/// @notice Delete token property value.
+	// /// @notice Delete token property value.
+	// /// @dev Throws error if `msg.sender` has no permission to edit the property.
+	// /// @param tokenId ID of the token.
+	// /// @param key Property key.
+	// /// @dev EVM selector for this function is: 0x066111d1,
+	// ///  or in textual repr: deleteProperty(uint256,string)
+	// function deleteProperty(uint256 tokenId, string memory key) external;
+
+	/// @notice Delete token properties value.
 	/// @dev Throws error if `msg.sender` has no permission to edit the property.
 	/// @param tokenId ID of the token.
-	/// @param key Property key.
-	/// @dev EVM selector for this function is: 0x066111d1,
-	///  or in textual repr: deleteProperty(uint256,string)
-	function deleteProperty(uint256 tokenId, string memory key) external;
+	/// @param keys Properties key.
+	/// @dev EVM selector for this function is: 0xc472d371,
+	///  or in textual repr: deleteProperties(uint256,string[])
+	function deleteProperties(uint256 tokenId, string[] memory keys) external;
 
 	/// @notice Get token property value.
 	/// @dev Throws error if key not found

--- a/tests/src/eth/api/UniqueRefungible.sol
+++ b/tests/src/eth/api/UniqueRefungible.sol
@@ -13,7 +13,7 @@ interface ERC165 is Dummy {
 }
 
 /// @title A contract that allows to set and delete token properties and change token property permissions.
-/// @dev the ERC-165 identifier for this interface is 0x55dba919
+/// @dev the ERC-165 identifier for this interface is 0x91a97a68
 interface TokenProperties is Dummy, ERC165 {
 	/// @notice Set permissions for token property.
 	/// @dev Throws error if `msg.sender` is not admin or owner of the collection.
@@ -51,13 +51,21 @@ interface TokenProperties is Dummy, ERC165 {
 	///  or in textual repr: setProperties(uint256,(string,bytes)[])
 	function setProperties(uint256 tokenId, Tuple20[] memory properties) external;
 
-	/// @notice Delete token property value.
+	// /// @notice Delete token property value.
+	// /// @dev Throws error if `msg.sender` has no permission to edit the property.
+	// /// @param tokenId ID of the token.
+	// /// @param key Property key.
+	// /// @dev EVM selector for this function is: 0x066111d1,
+	// ///  or in textual repr: deleteProperty(uint256,string)
+	// function deleteProperty(uint256 tokenId, string memory key) external;
+
+	/// @notice Delete token properties value.
 	/// @dev Throws error if `msg.sender` has no permission to edit the property.
 	/// @param tokenId ID of the token.
-	/// @param key Property key.
-	/// @dev EVM selector for this function is: 0x066111d1,
-	///  or in textual repr: deleteProperty(uint256,string)
-	function deleteProperty(uint256 tokenId, string memory key) external;
+	/// @param keys Properties key.
+	/// @dev EVM selector for this function is: 0xc472d371,
+	///  or in textual repr: deleteProperties(uint256,string[])
+	function deleteProperties(uint256 tokenId, string[] memory keys) external;
 
 	/// @notice Get token property value.
 	/// @dev Throws error if key not found

--- a/tests/src/eth/collectionProperties.test.ts
+++ b/tests/src/eth/collectionProperties.test.ts
@@ -139,7 +139,7 @@ describe('Supports ERC721Metadata', () => {
     await contract.methods.setProperty(tokenId1, 'URI', Buffer.from(URI)).send();
     expect(await contract.methods.tokenURI(tokenId1).call()).to.equal(URI);
 
-    await contract.methods.deleteProperty(tokenId1, 'URI').send();
+    await contract.methods.deleteProperties(tokenId1, ['URI']).send();
     expect(await contract.methods.tokenURI(tokenId1).call()).to.equal(BASE_URI + SUFFIX);
 
     const token2Result = await contract.methods.mintWithTokenURI(bruh, URI).send();
@@ -147,7 +147,7 @@ describe('Supports ERC721Metadata', () => {
 
     expect(await contract.methods.tokenURI(tokenId2).call()).to.equal(URI);
 
-    await contract.methods.deleteProperty(tokenId2, 'URI').send();
+    await contract.methods.deleteProperties(tokenId2, ['URI']).send();
     expect(await contract.methods.tokenURI(tokenId2).call()).to.equal(BASE_URI);
 
     await contract.methods.setProperty(tokenId2, 'URISuffix', Buffer.from(SUFFIX)).send();

--- a/tests/src/eth/nonFungibleAbi.json
+++ b/tests/src/eth/nonFungibleAbi.json
@@ -334,9 +334,9 @@
   {
     "inputs": [
       { "internalType": "uint256", "name": "tokenId", "type": "uint256" },
-      { "internalType": "string", "name": "key", "type": "string" }
+      { "internalType": "string[]", "name": "keys", "type": "string[]" }
     ],
-    "name": "deleteProperty",
+    "name": "deleteProperties",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/tests/src/eth/reFungibleAbi.json
+++ b/tests/src/eth/reFungibleAbi.json
@@ -316,9 +316,9 @@
   {
     "inputs": [
       { "internalType": "uint256", "name": "tokenId", "type": "uint256" },
-      { "internalType": "string", "name": "key", "type": "string" }
+      { "internalType": "string[]", "name": "keys", "type": "string[]" }
     ],
-    "name": "deleteProperty",
+    "name": "deleteProperties",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/tests/src/eth/tokenProperties.test.ts
+++ b/tests/src/eth/tokenProperties.test.ts
@@ -138,18 +138,25 @@ describe('EVM token properties', () => {
           mutable: true,
           collectionAdmin: true,
         },
+      },
+      {
+        key: 'testKey_1',
+        permission: {
+          mutable: true,
+          collectionAdmin: true,
+        },
       }],
     });
     
     const token = await collection.mintToken(alice);
-    await token.setProperties(alice, [{key: 'testKey', value: 'testValue'}]);
+    await token.setProperties(alice, [{key: 'testKey', value: 'testValue'}, {key: 'testKey_1', value: 'testValue_1'}]);
 
     await collection.addAdmin(alice, {Ethereum: caller});
 
     const address = helper.ethAddress.fromCollectionId(collection.collectionId);
     const contract = helper.ethNativeContract.collection(address, 'nft', caller);
 
-    await contract.methods.deleteProperty(token.tokenId, 'testKey').send({from: caller});
+    await contract.methods.deleteProperties(token.tokenId, ['testKey', 'testKey_1']).send({from: caller});
 
     const result = await token.getProperties(['testKey']);
     expect(result.length).to.equal(0);


### PR DESCRIPTION
Added `delete_properties` in eth functions. The `delete_property` function is now deprecated.