### PR TITLE
Tests/eth helpers

### DIFF
--- a/tests/src/eth/allowlist.test.ts
+++ b/tests/src/eth/allowlist.test.ts
@@ -91,7 +91,7 @@ describe('EVM collection allowlist', () => {
     expect(await collectionEvm.methods.allowlistedCross(crossUser).call({from: owner})).to.be.false;
   });
 
-  itEth.only('Collection allowlist can be added and removed by [cross] address', async ({helper}) => {
+  itEth('Collection allowlist can be added and removed by [cross] address', async ({helper}) => {
     const owner = (await helper.eth.createAccountWithBalance(donor)).toLowerCase();
     const [userSub] = await helper.arrange.createAccounts([10n], donor);
     const userEth = await helper.eth.createAccountWithBalance(donor);
@@ -100,6 +100,7 @@ describe('EVM collection allowlist', () => {
     const collectionEvm = helper.ethNativeContract.collection(collectionAddress, 'nft', owner);
     const userCrossSub = helper.ethCrossAccount.fromKeyringPair(userSub);
     const userCrossEth = helper.ethCrossAccount.fromAddress(userEth);
+    const ownerCrossEth = helper.ethCrossAccount.fromAddress(owner);
     
     // Can addToCollectionAllowListCross:
     expect(await helper.collection.allowed(collectionId, {Substrate: userSub.address})).to.be.false;
@@ -114,6 +115,7 @@ describe('EVM collection allowlist', () => {
     await collectionEvm.methods.mint(userEth).send();
     await collectionEvm.methods.setCollectionAccess(1).send();
     await collectionEvm.methods.transfer(owner, 1).send({from: userEth}); // FIXME: why not?
+    // await collectionEvm.methods.transferCross(ownerCrossEth, 1).send({from: userEth}); // FIXME: why not?
     expect(await helper.nft.getTokenOwner(collectionId, 1)).to.eq({Ethereum: owner});
     
     // can removeFromCollectionAllowListCross

--- a/tests/src/eth/collectionAdmin.test.ts
+++ b/tests/src/eth/collectionAdmin.test.ts
@@ -39,80 +39,94 @@ describe('Add collection admins', () => {
     });
   });
 
-  // Soft-deprecated
-  itEth('Add admin by owner', async ({helper}) => {
+  itEth('can add account admin by owner', async ({helper, privateKey}) => {
+    // arrange
     const owner = await helper.eth.createAccountWithBalance(donor);
-    const {collectionAddress, collectionId} = await helper.eth.createNFTCollection(owner, 'A', 'B', 'C');
-    const collectionEvm = helper.ethNativeContract.collection(collectionAddress, 'nft', owner, true);
+    const adminSub = await privateKey('//admin2');
+    const adminEth = helper.eth.createAccount().toLowerCase();
 
-    const newAdmin = helper.eth.createAccount();
-
-    await collectionEvm.methods.addCollectionAdmin(newAdmin).send();
-    const adminList = await helper.callRpc('api.rpc.unique.adminlist', [collectionId]);
-    expect(adminList[0].asEthereum.toString().toLocaleLowerCase())
-      .to.be.eq(newAdmin.toLocaleLowerCase());
-  });
-
-  itEth('Add cross account admin by owner', async ({helper, privateKey}) => {
-    const owner = await helper.eth.createAccountWithBalance(donor);
-        
-    const {collectionAddress, collectionId} = await helper.eth.createNFTCollection(owner, 'A', 'B', 'C');
-    const collectionEvm = helper.ethNativeContract.collection(collectionAddress, 'nft', owner);
-    
-    const newAdmin = await privateKey('//Bob');
-    const newAdminCross = helper.ethCrossAccount.fromKeyringPair(newAdmin);
-    await collectionEvm.methods.addCollectionAdminCross(newAdminCross).send();
-
-    const adminList = await helper.collection.getAdmins(collectionId);
-    expect(adminList).to.be.like([{Substrate: newAdmin.address}]);
-  });
-
-  itEth('Check adminlist', async ({helper, privateKey}) => {
-    const owner = await helper.eth.createAccountWithBalance(donor);
+    const adminDeprecated = helper.eth.createAccount().toLowerCase();
+    const adminCrossSub = helper.ethCrossAccount.fromKeyringPair(adminSub);
+    const adminCrossEth = helper.ethCrossAccount.fromAddress(adminEth);
         
     const {collectionAddress, collectionId} = await helper.eth.createNFTCollection(owner, 'A', 'B', 'C');
     const collectionEvm = helper.ethNativeContract.collection(collectionAddress, 'nft', owner, true);
 
-    const admin1 = helper.eth.createAccount();
-    const admin2 = await privateKey('admin');
-    const admin2Cross = helper.ethCrossAccount.fromKeyringPair(admin2);
-    
-    // Soft-deprecated
-    await collectionEvm.methods.addCollectionAdmin(admin1).send();
-    await collectionEvm.methods.addCollectionAdminCross(admin2Cross).send();
+    // Soft-deprecated: can addCollectionAdmin 
+    await collectionEvm.methods.addCollectionAdmin(adminDeprecated).send();
+    // Can addCollectionAdminCross for substrate and ethereum address
+    await collectionEvm.methods.addCollectionAdminCross(adminCrossSub).send();
+    await collectionEvm.methods.addCollectionAdminCross(adminCrossEth).send();
 
+    // 1. Expect api.rpc.unique.adminlist returns admins:
     const adminListRpc = await helper.collection.getAdmins(collectionId);
+    expect(adminListRpc).to.has.length(3);
+    expect(adminListRpc).to.be.deep.contain.members([{Substrate: adminSub.address}, {Ethereum: adminEth}, {Ethereum: adminDeprecated}]);
+
+    // 2. Expect methods.collectionAdmins == api.rpc.unique.adminlist
     let adminListEth = await collectionEvm.methods.collectionAdmins().call();
     adminListEth = adminListEth.map((element: IEthCrossAccountId) => {
-      return helper.address.convertCrossAccountFromEthCrossAcoount(element);
+      return helper.address.convertCrossAccountFromEthCrossAccount(element);
     });
     expect(adminListRpc).to.be.like(adminListEth);
   });
 
-  // Soft-deprecated
-  itEth('Verify owner or admin', async ({helper}) => {
+  itEth('cross account admin can mint', async ({helper}) => {
+    // arrange: create collection and accounts
     const owner = await helper.eth.createAccountWithBalance(donor);
-    const {collectionAddress} = await helper.eth.createNFTCollection(owner, 'A', 'B', 'C');
-
-    const newAdmin = helper.eth.createAccount();
+    const {collectionAddress, collectionId} = await helper.eth.createERC721MetadataCompatibleNFTCollection(owner, 'Mint collection', 'a', 'b', 'uri');
+    const adminEth = (await helper.eth.createAccountWithBalance(donor)).toLowerCase();
+    const adminCrossEth = helper.ethCrossAccount.fromAddress(adminEth);
     const collectionEvm = helper.ethNativeContract.collection(collectionAddress, 'nft', owner, true);
-  
-    expect(await collectionEvm.methods.isOwnerOrAdmin(newAdmin).call()).to.be.false;
-    await collectionEvm.methods.addCollectionAdmin(newAdmin).send();
-    expect(await collectionEvm.methods.isOwnerOrAdmin(newAdmin).call()).to.be.true;
+    
+    // cannot mint while not admin
+    await expect(collectionEvm.methods.mint(owner).call({from: adminEth})).to.be.rejectedWith('PublicMintingNotAllowed');
+    
+    // admin can mint token:
+    await collectionEvm.methods.addCollectionAdminCross(adminCrossEth).send();
+    const result = await collectionEvm.methods.mint(owner).call({from: adminEth});
+
+    // TODO: Why fail
+    expect(await helper.collection.getLastTokenId(collectionId)).to.eq(1);
   });
 
-  itEth('Verify owner or admin cross', async ({helper, privateKey}) => {
+  itEth('cannot add invalid cross account admin', async ({helper}) => {
+    const owner = await helper.eth.createAccountWithBalance(donor);
+    const [admin] = await helper.arrange.createAccounts([100n, 100n], donor);
+
+    const {collectionAddress} = await helper.eth.createNFTCollection(owner, 'A', 'B', 'C');
+    const collectionEvm = helper.ethNativeContract.collection(collectionAddress, 'nft', owner);
+
+    const adminCross = {
+      eth: helper.address.substrateToEth(admin.address),
+      sub: admin.addressRaw,
+    };
+    await expect(collectionEvm.methods.addCollectionAdminCross(adminCross).send()).to.be.rejected;
+  });
+
+  itEth('can verify owner with methods.isOwnerOrAdmin[Cross]', async ({helper, privateKey}) => {
     const owner = await helper.eth.createAccountWithBalance(donor);
     const {collectionAddress} = await helper.eth.createNFTCollection(owner, 'A', 'B', 'C');
 
-    const newAdmin = await privateKey('admin');
-    const newAdminCross = helper.ethCrossAccount.fromKeyringPair(newAdmin);
-    const collectionEvm = helper.ethNativeContract.collection(collectionAddress, 'nft', owner);
+    const adminDeprecated = helper.eth.createAccount();
+    const admin1Cross = helper.ethCrossAccount.fromKeyringPair(await privateKey('admin'));
+    const admin2Cross = helper.ethCrossAccount.fromAddress(helper.address.substrateToEth((await privateKey('admin3')).address));
+    const collectionEvm = helper.ethNativeContract.collection(collectionAddress, 'nft', owner, true);
   
-    expect(await collectionEvm.methods.isOwnerOrAdminCross(newAdminCross).call()).to.be.false;
-    await collectionEvm.methods.addCollectionAdminCross(newAdminCross).send();
-    expect(await collectionEvm.methods.isOwnerOrAdminCross(newAdminCross).call()).to.be.true;
+    // Soft-deprecated:
+    expect(await collectionEvm.methods.isOwnerOrAdmin(adminDeprecated).call()).to.be.false;
+    expect(await collectionEvm.methods.isOwnerOrAdminCross(admin1Cross).call()).to.be.false;
+    expect(await collectionEvm.methods.isOwnerOrAdminCross(admin2Cross).call()).to.be.false;
+
+    await collectionEvm.methods.addCollectionAdmin(adminDeprecated).send();
+    await collectionEvm.methods.addCollectionAdminCross(admin1Cross).send();
+    await collectionEvm.methods.addCollectionAdminCross(admin2Cross).send();
+
+    // Soft-deprecated: isOwnerOrAdmin returns true
+    expect(await collectionEvm.methods.isOwnerOrAdmin(adminDeprecated).call()).to.be.true;
+    // Expect isOwnerOrAdminCross return true
+    expect(await collectionEvm.methods.isOwnerOrAdminCross(admin1Cross).call()).to.be.true;
+    expect(await collectionEvm.methods.isOwnerOrAdminCross(admin2Cross).call()).to.be.true;
   });
 
   // Soft-deprecated
@@ -154,12 +168,11 @@ describe('Add collection admins', () => {
     const owner = await helper.eth.createAccountWithBalance(donor);
     const {collectionAddress, collectionId} = await helper.eth.createNFTCollection(owner, 'A', 'B', 'C');
 
-    const [admin] = await helper.arrange.createAccounts([10n], donor);
+    const [admin, notAdmin] = await helper.arrange.createAccounts([10n, 10n], donor);
     const adminCross = helper.ethCrossAccount.fromKeyringPair(admin);
     const collectionEvm = helper.ethNativeContract.collection(collectionAddress, 'nft', owner);
     await collectionEvm.methods.addCollectionAdminCross(adminCross).send();
 
-    const [notAdmin] = await helper.arrange.createAccounts([10n], donor);
     const notAdminCross = helper.ethCrossAccount.fromKeyringPair(notAdmin);
     await expect(collectionEvm.methods.addCollectionAdminCross(notAdminCross).call({from: adminCross.eth}))
       .to.be.rejectedWith('NoPermission');

--- a/tests/src/eth/collectionAdmin.test.ts
+++ b/tests/src/eth/collectionAdmin.test.ts
@@ -80,13 +80,12 @@ describe('Add collection admins', () => {
     const collectionEvm = helper.ethNativeContract.collection(collectionAddress, 'nft', owner, true);
     
     // cannot mint while not admin
-    await expect(collectionEvm.methods.mint(owner).call({from: adminEth})).to.be.rejectedWith('PublicMintingNotAllowed');
+    await expect(collectionEvm.methods.mint(owner).send({from: adminEth})).to.be.rejectedWith('PublicMintingNotAllowed');
     
     // admin can mint token:
     await collectionEvm.methods.addCollectionAdminCross(adminCrossEth).send();
-    const result = await collectionEvm.methods.mint(owner).call({from: adminEth});
+    await collectionEvm.methods.mint(owner).send({from: adminEth});
 
-    // TODO: Why fail
     expect(await helper.collection.getLastTokenId(collectionId)).to.eq(1);
   });
 

--- a/tests/src/eth/fungible.test.ts
+++ b/tests/src/eth/fungible.test.ts
@@ -314,7 +314,7 @@ describe('Fungible: Plain calls', () => {
     }
   });
 
-  itEth('Can perform transferFromCross()', async ({helper, privateKey}) => {
+  itEth('Can perform transferFromCross()', async ({helper}) => {
     const sender = await helper.eth.createAccountWithBalance(donor, 100n);
 
     const collection = await helper.ft.mintCollection(owner, {name: 'A', description: 'B', tokenPrefix: 'C'}, 0);
@@ -508,7 +508,7 @@ describe('Fungible: Substrate calls', () => {
     expect(event.returnValues.value).to.be.equal('51');
   });
 
-  itEth('Events emitted for transferFromCross()', async ({helper, privateKey}) => {
+  itEth('Events emitted for transferFromCross()', async ({helper}) => {
     const sender = await helper.eth.createAccountWithBalance(donor, 100n);
 
     const collection = await helper.ft.mintCollection(owner, {name: 'A', description: 'B', tokenPrefix: 'C'}, 0);

--- a/tests/src/eth/nonFungible.test.ts
+++ b/tests/src/eth/nonFungible.test.ts
@@ -360,13 +360,11 @@ describe('NFT: Plain calls', () => {
     }
   });
 
-  itEth('Can perform transferFromCross()', async ({helper, privateKey}) => {
-    const minter = await privateKey('//Alice');
+  itEth('Can perform transferFromCross()', async ({helper}) => {
     const collection = await helper.nft.mintCollection(minter, {name: 'A', description: 'B', tokenPrefix: 'C'});
 
-    const owner = await privateKey('//Bob');
+    const [owner, receiver] = await helper.arrange.createAccounts([100n, 100n], donor);
     const spender = await helper.eth.createAccountWithBalance(donor);
-    const receiver = await privateKey('//Charlie');
 
     const token = await collection.mintToken(minter, {Substrate: owner.address});
 

--- a/tests/src/eth/nonFungible.test.ts
+++ b/tests/src/eth/nonFungible.test.ts
@@ -17,7 +17,6 @@
 import {itEth, usingEthPlaygrounds, expect, EthUniqueHelper} from './util';
 import {IKeyringPair} from '@polkadot/types/types';
 import {Contract} from 'web3-eth-contract';
-import exp from 'constants';
 
 
 describe('NFT: Information getting', () => {
@@ -280,30 +279,51 @@ describe('NFT: Plain calls', () => {
   });
 
   itEth('Can perform approveCross()', async ({helper}) => {
-    const collection = await helper.nft.mintCollection(minter, {name: 'A', description: 'B', tokenPrefix: 'C'});
-
+    // arrange: create accounts
     const owner = await helper.eth.createAccountWithBalance(donor, 100n);
-    const receiver = charlie;
+    const ownerCross = helper.ethCrossAccount.fromAddress(owner);
+    const receiverSub = charlie;
+    const recieverCrossSub = helper.ethCrossAccount.fromKeyringPair(receiverSub);
+    const receiverEth = await helper.eth.createAccountWithBalance(donor, 100n);
+    const receiverCrossEth = helper.ethCrossAccount.fromAddress(receiverEth);
 
-    const token = await collection.mintToken(minter, {Ethereum: owner});
+    // arrange: create collection and tokens:
+    const collection = await helper.nft.mintCollection(minter, {name: 'A', description: 'B', tokenPrefix: 'C'});
+    const token1 = await collection.mintToken(minter, {Ethereum: owner});
+    const token2 = await collection.mintToken(minter, {Ethereum: owner});
 
-    const address = helper.ethAddress.fromCollectionId(collection.collectionId);
-    const contract = helper.ethNativeContract.collection(address, 'nft');
+    const collectionEvm = helper.ethNativeContract.collection(helper.ethAddress.fromCollectionId(collection.collectionId), 'nft');
 
-    {
-      const recieverCross = helper.ethCrossAccount.fromKeyringPair(receiver);
-      const result = await contract.methods.approveCross(recieverCross, token.tokenId).send({from: owner});
-      const event = result.events.Approval;
-      expect(event).to.be.like({
-        address: helper.ethAddress.fromCollectionId(collection.collectionId),
-        event: 'Approval',
-        returnValues: {
-          owner,
-          approved: helper.address.substrateToEth(receiver.address),
-          tokenId: token.tokenId.toString(),
-        },
-      });
-    }
+    // Can approveCross substrate and ethereum address:
+    const resultSub = await collectionEvm.methods.approveCross(recieverCrossSub, token1.tokenId).send({from: owner});
+    const resultEth = await collectionEvm.methods.approveCross(receiverCrossEth, token2.tokenId).send({from: owner});
+    const eventSub = resultSub.events.Approval;
+    const eventEth = resultEth.events.Approval;
+    expect(eventSub).to.be.like({
+      address: helper.ethAddress.fromCollectionId(collection.collectionId),
+      event: 'Approval',
+      returnValues: {
+        owner,
+        approved: helper.address.substrateToEth(receiverSub.address),
+        tokenId: token1.tokenId.toString(),
+      },
+    });
+    expect(eventEth).to.be.like({
+      address: helper.ethAddress.fromCollectionId(collection.collectionId),
+      event: 'Approval',
+      returnValues: {
+        owner,
+        approved: receiverEth,
+        tokenId: token2.tokenId.toString(),
+      },
+    });
+
+    // Substrate address can transferFrom approved tokens:
+    await helper.nft.transferTokenFrom(receiverSub, collection.collectionId, token1.tokenId, {Ethereum: owner}, {Substrate: receiverSub.address});
+    expect(await helper.nft.getTokenOwner(collection.collectionId, token1.tokenId)).to.deep.eq({Substrate: receiverSub.address});
+    // Ethereum address can transferFromCross approved tokens:
+    await collectionEvm.methods.transferFromCross(ownerCross, receiverCrossEth, token2.tokenId).send({from: receiverEth});
+    expect(await helper.nft.getTokenOwner(collection.collectionId, token2.tokenId)).to.deep.eq({Ethereum: receiverEth.toLowerCase()});
   });
 
   itEth('Can perform transferFrom()', async ({helper}) => {
@@ -501,7 +521,7 @@ describe('NFT: Fees', () => {
     expect(cost < BigInt(0.2 * Number(helper.balance.getOneTokenNominal())));
   });
 
-  itEth('Can perform transferFromCross()', async ({helper, privateKey}) => {
+  itEth('Can perform transferFromCross()', async ({helper}) => {
     const collectionMinter = alice;
     const owner = bob;
     const receiver = charlie;

--- a/tests/src/util/playgrounds/unique.ts
+++ b/tests/src/util/playgrounds/unique.ts
@@ -2429,7 +2429,7 @@ class AddressGroup extends HelperGroup<ChainHelperBase> {
    * @param ethCrossAccount etherium cross account
    * @returns substrate cross account id
    */
-  convertCrossAccountFromEthCrossAcoount(ethCrossAccount: IEthCrossAccountId): ICrossAccountId {
+  convertCrossAccountFromEthCrossAccount(ethCrossAccount: IEthCrossAccountId): ICrossAccountId {
     if (ethCrossAccount.sub === '0') {
       return {Ethereum: ethCrossAccount.eth.toLocaleLowerCase()};
     }


### PR DESCRIPTION
- account added to allow list cross (addToCollectionAllowListCross) can transfer tokens
- approved cross accounts can transferCross
- Check both cross ethereum and cross substrate addresses