### PR TITLE
fix: pallet xcm settings

### DIFF
--- a/runtime/common/config/xcm/mod.rs
+++ b/runtime/common/config/xcm/mod.rs
@@ -221,7 +221,7 @@ where
 	type Barrier = Barrier;
 	type Weigher = Weigher;
 	type Trader = Trader<T>;
-	type ResponseHandler = (); // Don't handle responses for now.
+	type ResponseHandler = PolkadotXcm;
 	type SubscriptionService = PolkadotXcm;
 
 	type AssetTrap = PolkadotXcm;

--- a/runtime/common/construct_runtime.rs
+++ b/runtime/common/construct_runtime.rs
@@ -61,7 +61,7 @@ macro_rules! construct_runtime {
 
                 // XCM helpers.
                 XcmpQueue: cumulus_pallet_xcmp_queue::{Pallet, Call, Storage, Event<T>} = 50,
-                PolkadotXcm: pallet_xcm::{Pallet, Call, Event<T>, Origin} = 51,
+                PolkadotXcm: pallet_xcm::{Pallet, Call, Storage, Event<T>, Origin} = 51,
                 CumulusXcm: cumulus_pallet_xcm::{Pallet, Call, Event<T>, Origin} = 52,
                 DmpQueue: cumulus_pallet_dmp_queue::{Pallet, Call, Storage, Event<T>} = 53,
 

--- a/runtime/common/construct_runtime.rs
+++ b/runtime/common/construct_runtime.rs
@@ -39,7 +39,7 @@ macro_rules! construct_runtime {
                 Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>} = 24,
 
                 Aura: pallet_aura::{Pallet, Storage, Config<T>} = 25,
-                AuraExt: cumulus_pallet_aura_ext::{Pallet, Config} = 26,
+                AuraExt: cumulus_pallet_aura_ext::{Pallet, Storage, Config} = 26,
 
                 Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>} = 30,
                 RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Pallet, Storage} = 31,

--- a/runtime/common/construct_runtime.rs
+++ b/runtime/common/construct_runtime.rs
@@ -38,7 +38,7 @@ macro_rules! construct_runtime {
                 #[cfg(feature = "collator-selection")]
                 Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>} = 24,
 
-                Aura: pallet_aura::{Pallet, Config<T>} = 25,
+                Aura: pallet_aura::{Pallet, Storage, Config<T>} = 25,
                 AuraExt: cumulus_pallet_aura_ext::{Pallet, Config} = 26,
 
                 Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>} = 30,


### PR DESCRIPTION
1. We must expose the pallet XCM storage to examine its state easily. We could be interested in the following:
    * Asset traps
    * Other chains supported versions
    * XCM migration state
2. Set the pallet XCM as the response handler to handle sibling parachins' version changes 