### PR TITLE
fix: remove double Option wrapping for propertyKeys

### DIFF
--- a/tests/src/interfaces/unique/definitions.ts
+++ b/tests/src/interfaces/unique/definitions.ts
@@ -24,7 +24,7 @@ const CROSS_ACCOUNT_ID_TYPE = 'PalletEvmAccountBasicCrossAccountIdRepr';
 
 const collectionParam = {name: 'collection', type: 'u32'};
 const tokenParam = {name: 'tokenId', type: 'u32'};
-const propertyKeysParam = {name: 'propertyKeys', type: 'Option<Vec<String>>', isOptional: true};
+const propertyKeysParam = {name: 'propertyKeys', type: 'Vec<String>', isOptional: true};
 const crossAccountParam = (name = 'account') => ({name, type: CROSS_ACCOUNT_ID_TYPE});
 const atParam = {name: 'at', type: 'Hash', isOptional: true};
 


### PR DESCRIPTION
Polkadot.js неверно понимает что от него требуется в этом случае. Хоть RPC и работает через JSON, параметры кодируются через модель данных scale, а соответственно Option<Option<T>> не то же самое что и Option<T>, как это происходит с T?? vs T? в typescript